### PR TITLE
Friendlier and adaptative download

### DIFF
--- a/datasetUtils.py
+++ b/datasetUtils.py
@@ -391,6 +391,10 @@ def mergeDatasets(dataset1, dataset2, output):
             else:
                 f.write(line)
 
+def delete_merged_datasets(output):
+    """Deletes the merged datasets."""
+    shutil.rmtree(output)
+
 # -------------------------------------------------  Display util functions -------------------------------------------------
 def colorFromClass(classID):
     """Returns a color for a class ID. Colors are selected among the list available here : https://matplotlib.org/stable/gallery/color/named_colors.html"""

--- a/datasetUtils.py
+++ b/datasetUtils.py
@@ -72,7 +72,7 @@ def delete_roboflow_dataset(ver):
 def dl_taco_dataset():
     """Downloads the TACO dataset."""
     # clone repo, install requirements
-    os.system('git clone https://github.com/pedropro/TACO.git')
+    os.system('git clone https://github.com/pedropro/TACO.git --quiet')
     os.system('pip install -r ./TACO/requirements.txt')
     
     # replace download.py for a paralellized + functional version from pr

--- a/datasetUtils.py
+++ b/datasetUtils.py
@@ -73,7 +73,7 @@ def dl_taco_dataset():
     """Downloads the TACO dataset."""
     # clone repo, install requirements
     os.system('git clone https://github.com/pedropro/TACO.git --quiet')
-    os.system('pip install -r ./TACO/requirements.txt')
+    os.system('pip install -r ./TACO/requirements.txt --quiet')
     
     # replace download.py for a paralellized + functional version from pr
     os.system('rm -rf ./TACO/download.py')

--- a/getAndMergeDatasets.py
+++ b/getAndMergeDatasets.py
@@ -4,27 +4,40 @@ import datasetUtils as du
 import os
 import shutil
 
-if __name__ == '__main__':
+
+def launch_full_download(roboflow_version, delete_datasets_after_merge, get_all_fresh_datasets, outputPath):
     # Select roboflow version here
-    roboflow_version = 2
-    delete_datasets_after_merge = False
+
+    if get_all_fresh_datasets:
+        print('Deleting datasets')
+        du.delete_roboflow_dataset()
+        du.delete_TACO_dataset()
+        du.delete_merged_datasets(outputPath)
 
     if not (os.path.exists('./datasets')):
         os.mkdir('./datasets')
+    else:
+        print('Datasets folder already exists')
 
     if not (os.path.exists('./datasets/Dataset-ViPARE-' + str(roboflow_version) + '/images')):
         print('Downloading Roboflow dataset version ' + str(roboflow_version) + '...')
         du.dl_roboflow_dataset(roboflow_version)
+    else:
+        print('Roboflow dataset version ' + str(roboflow_version) + ' already exists')
 
     if not (os.path.exists('./datasets/TACO')):
         print('Downloading TACO dataset')
         du.dl_taco_dataset()
+    else:
+        print('TACO dataset already exists')
 
     if not (os.path.exists('./datasetsTACO/data/yolo')):
         print('Converting TACO dataset to YOLO format')
         du.cocoToYolo('./datasets/TACO/data')
         du.split_dataset('./datasets/TACO/data/yolo', 0.7, 0.2, 0.1)
         du.tacoClassesToNaia('./datasets/TACO/data/yolo/')
+    else:
+        print('TACO dataset already in YOLO format')
 
     if not (os.path.exists('./datasets/mergeDataset')):
         print('Merging datasets')
@@ -45,9 +58,18 @@ if __name__ == '__main__':
 
         shutil.copy("./datasets/data.yaml", path + "/data.yaml")
         du.mergeDatasets('./datasets/Dataset-ViPARE-' + str(roboflow_version), './datasets/TACO/data/yolo', './datasets/mergeDataset')
+    else:
+        print('Merged dataset already exists, not modifying it')
 
     if delete_datasets_after_merge:
         print('Deleting datasets')
         du.delete_roboflow_dataset()
         du.delete_TACO_dataset()
 
+if __name__ == '__main__':
+    roboflow_version = 4
+    delete_datasets_after_merge = False
+    get_all_fresh_datasets = False
+    outputPath = './datasets/mergeDataset'
+    #TODO : add arge parser to get roboflow_version and delete_datasets_after_merge and get_all_fresh_datasets from command line
+    launch_full_download(roboflow_version, delete_datasets_after_merge, get_all_fresh_datasets, outputPath)

--- a/getAndMergeDatasets.py
+++ b/getAndMergeDatasets.py
@@ -3,7 +3,7 @@ import datasetUtils as du
 
 import os
 import shutil
-
+import argparse
 
 def launch_full_download(roboflow_version, delete_datasets_after_merge, get_all_fresh_datasets, outputPath):
     # Select roboflow version here
@@ -67,9 +67,16 @@ def launch_full_download(roboflow_version, delete_datasets_after_merge, get_all_
         du.delete_TACO_dataset()
 
 if __name__ == '__main__':
-    roboflow_version = 4
-    delete_datasets_after_merge = False
-    get_all_fresh_datasets = False
-    outputPath = './datasets/mergeDataset'
-    #TODO : add arge parser to get roboflow_version and delete_datasets_after_merge and get_all_fresh_datasets from command line
+    parser = argparse.ArgumentParser(description='Download and merge datasets')
+    parser.add_argument('--version', type=int, default=4, help='Roboflow version to download')
+    parser.add_argument('--delete', type=bool, default=False, help='Delete base datasets used for merge after merge')
+    parser.add_argument('--fresh', type=bool, default=False, help='Delete all datasets before downloading, to ensure a fresh download')
+    parser.add_argument('--output', type=str, default='./datasets/mergeDataset', help='Output path for merged dataset')
+
+    args = parser.parse_args()
+    roboflow_version = args.version
+    delete_datasets_after_merge = args.delete
+    get_all_fresh_datasets = args.fresh
+    outputPath = args.output
+
     launch_full_download(roboflow_version, delete_datasets_after_merge, get_all_fresh_datasets, outputPath)

--- a/getAndMergeDatasets.py
+++ b/getAndMergeDatasets.py
@@ -63,7 +63,7 @@ def launch_full_download(roboflow_version, delete_datasets_after_merge, get_all_
 
     if delete_datasets_after_merge:
         print('Deleting datasets')
-        du.delete_roboflow_dataset()
+        du.delete_roboflow_dataset(roboflow_version)
         du.delete_TACO_dataset()
 
 if __name__ == '__main__':

--- a/getAndMergeDatasets.py
+++ b/getAndMergeDatasets.py
@@ -31,7 +31,7 @@ def launch_full_download(roboflow_version, delete_datasets_after_merge, get_all_
     else:
         print('TACO dataset already exists')
 
-    if not (os.path.exists('./datasetsTACO/data/yolo')):
+    if not (os.path.exists('./datasets/TACO/data/yolo')):
         print('Converting TACO dataset to YOLO format')
         du.cocoToYolo('./datasets/TACO/data')
         du.split_dataset('./datasets/TACO/data/yolo', 0.7, 0.2, 0.1)

--- a/getAndMergeDatasets.py
+++ b/getAndMergeDatasets.py
@@ -39,7 +39,7 @@ def launch_full_download(roboflow_version, delete_datasets_after_merge, get_all_
     else:
         print('TACO dataset already in YOLO format')
 
-    if not (os.path.exists('./datasets/mergeDataset')):
+    if not (os.path.exists(outputPath)):
         print('Merging datasets')
 
         path = './datasets/Dataset-ViPARE-' + str(roboflow_version)
@@ -57,7 +57,7 @@ def launch_full_download(roboflow_version, delete_datasets_after_merge, get_all_
             
 
         shutil.copy("./datasets/data.yaml", path + "/data.yaml")
-        du.mergeDatasets('./datasets/Dataset-ViPARE-' + str(roboflow_version), './datasets/TACO/data/yolo', './datasets/mergeDataset')
+        du.mergeDatasets('./datasets/Dataset-ViPARE-' + str(roboflow_version), './datasets/TACO/data/yolo', outputPath)
     else:
         print('Merged dataset already exists, not modifying it')
 


### PR DESCRIPTION
Added the possibility to give command line arguments for the launch of dataset download
You can now, from the command line call :
- Choose roboflow VIPARE project's version
- Choose to delete the datasets used for the merge once the merge is done, to avoid having too much data locally
- Choose to re-download ALL datasets used for the merge, to ensure a clean install
- Choose the output directory for the mergeDataset